### PR TITLE
fix main reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "author": "Jeremy Danyow <jdanyow@gmail.com> (http://danyow.net/)",
-  "main": "dist/commonjs/index.js",
+  "main": "dist/commonjs/aurelia-async.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/jdanyow/aurelia-async"


### PR DESCRIPTION
In package.json, main references a nonexistent file - repairing.